### PR TITLE
docs: add init command guide and CLI UI analysis

### DIFF
--- a/CLI界面设计分析/README.md
+++ b/CLI界面设计分析/README.md
@@ -1,0 +1,36 @@
+# CLI 界面设计分析
+
+## 架构概览
+- CLI 前端基于 [Ink](https://github.com/vadimdemedes/ink) 构建，利用 React 组件在终端渲染。
+- 根组件 `App` 通过 `<Static>` 区域输出历史记录，避免重绘抖动【F:packages/cli/src/ui/App.tsx†L912-L947】。
+- 消息以 `HistoryItem` 形式存储，由 `HistoryItemDisplay` 组件根据类型渲染不同结构【F:packages/cli/src/ui/components/HistoryItemDisplay.tsx†L47-L66】。
+
+## 实时思考过程展示
+- 钩子 `useGeminiStream` 订阅 Gemini 的流式事件，并在接收到 `Thought` 事件时更新思考内容【F:packages/cli/src/ui/hooks/useGeminiStream.ts†L563-L568】。
+- 每次新对话开始时会清空思考状态，避免旧信息残留【F:packages/cli/src/ui/hooks/useGeminiStream.ts†L666-L669】。
+- `LoadingIndicator` 从上下文获取当前思考并展示在界面上【F:packages/cli/src/ui/components/LoadingIndicator.tsx†L22-L40】【F:packages/cli/src/ui/components/LoadingIndicator.tsx†L64-L66】。
+
+## 结构化响应展示
+- `HistoryItemDisplay` 根据 `HistoryItem` 的 `type` 渲染用户消息、模型回复、工具调用等不同组件【F:packages/cli/src/ui/components/HistoryItemDisplay.tsx†L47-L66】。
+
+## 全流程流程图
+```mermaid
+graph TD
+  UserInput[用户输入] -->|submit| useGeminiStream
+  useGeminiStream -->|发送| GeminiAPI
+  GeminiAPI -->|Thought/Content 事件| useGeminiStream
+  useGeminiStream -->|更新| History[历史记录]
+  useGeminiStream -->|setThought| LoadingIndicator
+  History -->|渲染| StaticArea[<Static>]
+  StaticArea --> CLI[终端界面]
+  LoadingIndicator --> CLI
+```
+
+## 设计要点
+- 通过 `StreamingState` 管理响应、等待确认等状态，实现 `esc` 取消和工具执行反馈【F:packages/cli/src/ui/hooks/useGeminiStream.ts†L164-L185】【F:packages/cli/src/ui/components/LoadingIndicator.tsx†L31-L44】。
+- `HistoryItem` 结构保证输出可被解析并与工具结果、错误信息等组合展示。
+
+## 后续优化
+- 支持更丰富的思考可视化，如分阶段的 `ThoughtSummary` 展示。
+- 引入性能监控，评估 `<Static>` 与消息分片策略的效果。
+

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -130,8 +130,8 @@ Slash commands provide meta-level control over the CLI itself.
     - **Persistent setting:** Vim mode preference is saved to `~/.gemini/settings.json` and restored between sessions
   - **Status indicator:** When enabled, shows `[NORMAL]` or `[INSERT]` in the footer
 
-- **`/init`**
-  - **Description:** To help users easily create a `GEMINI.md` file, this command analyzes the current directory and generates a tailored context file, making it simpler for them to provide project-specific instructions to the Gemini agent.
+  - **`/init`**
+    - **Description:** To help users easily create a `GEMINI.md` file, this command analyzes the current directory and generates a tailored context file, making it simpler for them to provide project-specific instructions to the Gemini agent. See [init command](./init.md) for details.
 
 ### Custom Commands
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -6,6 +6,7 @@ Within Gemini CLI, `packages/cli` is the frontend for users to send and receive 
 
 - **[Authentication](./authentication.md):** A guide to setting up authentication with Google's AI services.
 - **[Commands](./commands.md):** A reference for Gemini CLI commands (e.g., `/help`, `/tools`, `/theme`).
+- **[Init](./init.md):** Generate a `GEMINI.md` file for your project.
 - **[Configuration](./configuration.md):** A guide to tailoring Gemini CLI behavior using configuration files.
 - **[Enterprise](./enterprise.md):** A guide to enterprise configuration.
 - **[Token Caching](./token-caching.md):** Optimize API costs through token caching.

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -1,0 +1,21 @@
+# /init command
+
+The `/init` command bootstraps a `GEMINI.md` file for your project. When invoked, the command analyzes the current directory and creates a tailored instruction file that the Gemini agent will use as context.
+
+## Usage
+
+1. Run Gemini CLI in the root of your project.
+2. At the prompt, type `/init`.
+3. If no `GEMINI.md` exists, the CLI creates one and asks Gemini to inspect the project and populate the file.
+4. Review the generated content and commit the file to version control.
+
+If a `GEMINI.md` already exists, the command prints an informational message and makes no changes.
+
+## Example
+
+```bash
+gemini
+> /init
+```
+
+The CLI will create `GEMINI.md` and populate it using an AI-generated analysis of the project. Treat the result as a starting point—edit the file as needed to reflect your project's conventions.


### PR DESCRIPTION
## Summary
- document `/init` command for bootstrapping a GEMINI.md file
- add Chinese-language analysis of CLI UI architecture and real-time thought streaming

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*
- `npm run build` *(fails: Command failed: tsc --build)*


------
https://chatgpt.com/codex/tasks/task_e_68a7cc37aba0833293155152786a3dbd